### PR TITLE
Add missing mapping for m5.xlarge

### DIFF
--- a/aws_emr_blog_v1/cloudformation/ranger-server.template
+++ b/aws_emr_blog_v1/cloudformation/ranger-server.template
@@ -173,6 +173,8 @@ Mappings:
       Arch: HVM64
     m4.10xlarge:
       Arch: HVM64
+    m5.xlarge:
+      Arch: HVM64
     c1.medium:
       Arch: PV64
     c1.xlarge:


### PR DESCRIPTION
*Issue #36:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
Add missing mapping for m5.xlarge